### PR TITLE
Pass metalsmith objects into jquery callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Metalsmith(__dirname)
     });
 ``` 
 
+Inside your callback, you can access the metalsmith-metadata, and metalsmith filename
+
+```js
+    .use(jquery(function($, filename, files, metalsmith) {
+        var title = $('h1').first().text()
+        if (title)
+            files[filename].title = title
+    }))
+```
+
 You can also store the javascript in a separate file, which is especially useful if you're managing your Metalsmith configuration in a JSON file:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Inside your callback, you can access the metalsmith-metadata, and metalsmith fil
 
 ```js
     .use(jquery(function($, filename, files, metalsmith) {
-        var title = $('h1').first().text()
+        var title = $('h1').first().text();
         if (title)
-            files[filename].title = title
+            files[filename].title = title;
     }))
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = function(param) {
 
         Object.keys(files).forEach(function(file) {
             var page = cheerio.load(files[file].contents);
-            transform(page);
+            transform(page, file, files, metalsmith);
             files[file].contents = new Buffer(page.html());
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metalsmith-jquery",
-    "version": "0.0.2",
+    "version": "0.1.2",
     "description": "A Metalsmith plugin to manipulate HTML via jQuery syntax",
     "keywords": [
         "metalsmith",

--- a/test/index.js
+++ b/test/index.js
@@ -80,5 +80,28 @@ describe('metalsmith-jquery', function() {
                 }
             });
     });
+
+    it('should provide access to the metalsmith metadata', function(done){
+        var metalsmith = Metalsmith('test/fixtures/basic');
+        metalsmith
+            .use(markdown())
+            .use(jquery(function($, filename, files, metalsmith) {
+                // generate a random number, and insert it as h4 and as metalsmith metadata
+                var testData = '' + Math.floor(Math.random() * 9999);
+                $('h3').after('<h4 id="data">' + testData + '</h4>');
+                files[filename]['testData'] = testData;
+            }))
+            .build(function(err, files) {
+                if (err) {
+                    return(done(err));
+                } else {
+                    Object.keys(files).forEach(function(file) {
+                        $ = cheerio.load(files[file].contents);
+                        assert($('h4#data').text(), files[file]['testData']);
+                    });
+                    done();
+                }
+            });
+    });
     
 });


### PR DESCRIPTION
This lets you access the metalsmith metadata from your jquery callback. See the README.md diff for an example. 